### PR TITLE
Remove uses of `extern crate`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,3 @@
-extern crate aseprite;
-extern crate blit;
-extern crate git2;
-extern crate image;
-extern crate serde_json;
-
 use blit::*;
 use git2::Repository;
 use std::env;

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,5 +1,6 @@
 use collision::Discrete;
 use specs::*;
+use specs_derive::Component;
 
 use super::*;
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -2,6 +2,7 @@ use blit::*;
 use cgmath::Point2;
 use line_drawing::Bresenham;
 use specs::*;
+use specs_derive::Component;
 use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -1,6 +1,7 @@
 use cgmath::{EuclideanSpace, Point2};
 use collision::Aabb2;
 use specs::{Component, VecStorage};
+use specs_derive::Component;
 use std::ops::{Add, Deref, DerefMut};
 
 #[derive(Component, Debug, Copy, Clone)]

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,7 +1,9 @@
 use blit::*;
 use direct_gui::controls::*;
 use direct_gui::*;
+use rust_embed::RustEmbed;
 use specs::*;
+use specs_derive::Component;
 
 use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,3 @@
-extern crate blit;
-extern crate cgmath;
-extern crate collision;
-extern crate direct_gui;
-extern crate line_drawing;
-extern crate minifb;
-extern crate rand;
-extern crate specs;
-#[macro_use]
-extern crate specs_derive;
-#[macro_use]
-extern crate rust_embed;
-
 mod ai;
 mod draw;
 mod geom;
@@ -23,6 +10,7 @@ mod turret;
 mod unit;
 
 use minifb::*;
+use rust_embed::RustEmbed;
 use specs::{DispatcherBuilder, Join, World, WorldExt};
 use std::collections::HashMap;
 use std::thread::sleep;

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,4 +1,5 @@
 use specs::*;
+use specs_derive::Component;
 use std::time::Duration;
 
 use super::*;

--- a/src/projectile.rs
+++ b/src/projectile.rs
@@ -2,6 +2,7 @@ use collision::Discrete;
 use rand;
 use rand::distributions::{Distribution, Uniform};
 use specs::*;
+use specs_derive::Component;
 
 use super::*;
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,5 +1,6 @@
 use line_drawing::Bresenham;
 use specs::*;
+use specs_derive::Component;
 
 use crate::geom::*;
 use crate::physics::*;

--- a/src/turret.rs
+++ b/src/turret.rs
@@ -2,6 +2,7 @@ use cgmath::MetricSpace;
 use rand;
 use rand::distributions::{Distribution, Uniform};
 use specs::*;
+use specs_derive::Component;
 
 use super::*;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,6 +1,7 @@
 use cgmath::Point2;
 use collision::Discrete;
 use specs::*;
+use specs_derive::Component;
 
 use super::*;
 


### PR DESCRIPTION
According to the [rust docs](https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/path-clarity.html#no-more-extern-crate), `extern crate` is almost never needed as of Rust 2018. For cases where `#[macro_use]` was previously necessary (for external crates), [macros can now be imported via `use` statements](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/macros/macro-changes.html#macro_rules-style-macros).
